### PR TITLE
GraphsTest.isIntervalGraph Interface

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -499,7 +499,7 @@ public abstract class GraphTests
     /**
      * Tests whether a graph is an interval graph. <a href="https://en.wikipedia.org/wiki/Interval_graph">
      * Interval graphs</a> are a familiy of graphs, which can be represented as intersections of intervals.
-     * The vertex are intervals on the number line and two vertices are connected if and only if the intervals of
+     * The vertices are intervals on the number line and two vertices are connected if and only if the intervals of
      * these vertices intersect each other.
      * 
      * @param graph the input graph

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -499,7 +499,7 @@ public abstract class GraphTests
     /**
      * Tests whether a graph is an interval graph. <a href="https://en.wikipedia.org/wiki/Interval_graph">
      * Interval graphs</a> are a familiy of graphs, which can be represented as intersections of intervals.
-     * The vertex are intervals on the real line and two vertices are connected if and only if the intervals of
+     * The vertex are intervals on the number line and two vertices are connected if and only if the intervals of
      * these vertices intersect each other.
      * 
      * @param graph the input graph

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -495,6 +495,23 @@ public abstract class GraphTests
         Objects.requireNonNull(graph, GRAPH_CANNOT_BE_NULL);
         return new ChordalityInspector<>(graph).isChordal();
     }
+    
+    /**
+     * Tests whether a graph is an interval graph. <a href="https://en.wikipedia.org/wiki/Interval_graph">
+     * Interval graphs</a> are a familiy of graphs, which can be represented as intersections of intervals.
+     * The vertex are intervals on the real line and two vertices are connected if and only if the intervals of
+     * these vertices intersect each other.
+     * 
+     * @param graph the input graph
+     * @param <V> the graph vertex type
+     * @param <E> the graph edge type
+     * @return true if the graph is an interval graph, false otherwise
+     * @see TODO
+     * 
+     */
+    public static <V, E> boolean isIntervalGraph(Graph<V, E> graph) {
+        throw new UnsupportedOperationException("Not yet implemented!"); //TODO: Implement
+    }
 
     /**
      * Tests whether an undirected graph meets Ore's condition to be Hamiltonian.


### PR DESCRIPTION
I added the method GraphsTest.isIntervalGraph(graph), which will be required for the algorithm and which is an interface, I can use for my testing methods as long as we do not have an algorithm class in the intervalGraphs branch. I also added a documentation for this method.