### PR TITLE
Interval graphs tests

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -499,7 +499,7 @@ public abstract class GraphTests
     /**
      * Tests whether a graph is an interval graph. <a href="https://en.wikipedia.org/wiki/Interval_graph">
      * Interval graphs</a> are a familiy of graphs, which can be represented as intersections of intervals.
-     * The vertex are intervals on the number line and two vertices are connected if and only if the intervals of
+     * The vertices are intervals on the number line and two vertices are connected if and only if the intervals of
      * these vertices intersect each other.
      * 
      * @param graph the input graph

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -22,6 +22,7 @@ import org.jgrapht.alg.connectivity.ConnectivityInspector;
 import org.jgrapht.alg.connectivity.KosarajuStrongConnectivityInspector;
 import org.jgrapht.alg.cycle.ChordalityInspector;
 import org.jgrapht.alg.cycle.HierholzerEulerianCycle;
+import org.jgrapht.alg.intervalgraph.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -506,11 +507,12 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is an interval graph, false otherwise
-     * @see TODO
+     * @see IntervalGraphRecognizer#isIntervalGraph()
      * 
      */
     public static <V, E> boolean isIntervalGraph(Graph<V, E> graph) {
-        throw new UnsupportedOperationException("Not yet implemented!"); //TODO: Implement
+        Objects.requireNonNull(graph, GRAPH_CANNOT_BE_NULL);
+        return new IntervalGraphRecognizer<>(graph).isIntervalGraph();
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -499,7 +499,7 @@ public abstract class GraphTests
     /**
      * Tests whether a graph is an interval graph. <a href="https://en.wikipedia.org/wiki/Interval_graph">
      * Interval graphs</a> are a familiy of graphs, which can be represented as intersections of intervals.
-     * The vertex are intervals on the real line and two vertices are connected if and only if the intervals of
+     * The vertex are intervals on the number line and two vertices are connected if and only if the intervals of
      * these vertices intersect each other.
      * 
      * @param graph the input graph

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -495,6 +495,23 @@ public abstract class GraphTests
         Objects.requireNonNull(graph, GRAPH_CANNOT_BE_NULL);
         return new ChordalityInspector<>(graph).isChordal();
     }
+    
+    /**
+     * Tests whether a graph is an interval graph. <a href="https://en.wikipedia.org/wiki/Interval_graph">
+     * Interval graphs</a> are a familiy of graphs, which can be represented as intersections of intervals.
+     * The vertex are intervals on the real line and two vertices are connected if and only if the intervals of
+     * these vertices intersect each other.
+     * 
+     * @param graph the input graph
+     * @param <V> the graph vertex type
+     * @param <E> the graph edge type
+     * @return true if the graph is an interval graph, false otherwise
+     * @see TODO
+     * 
+     */
+    public static <V, E> boolean isIntervalGraph(Graph<V, E> graph) {
+        throw new UnsupportedOperationException("Not yet implemented!"); //TODO: Implement
+    }
 
     /**
      * Tests whether an undirected graph meets Ore's condition to be Hamiltonian.


### PR DESCRIPTION
Reopens the isInterval Method in GraphTests which is necessary according to the issue. Not the method actually works. But does not really anything special. Most important is the documentation above the method. Please check whether it is correct.